### PR TITLE
Add an audio player

### DIFF
--- a/main.py
+++ b/main.py
@@ -54,7 +54,7 @@ def upload_file():
         bucket = storage_client.get_bucket("dedbeetz-media")
         blob = bucket.blob('beetz/' + f.filename)
         blob.upload_from_file(f)
-    return ''
+    return 'http://noproblo.dayjo.org/ZeldaSounds/WW_New/WW_Salvatore_Sploosh.wav'
 
 
 if __name__ == '__main__':

--- a/vue/package.json
+++ b/vue/package.json
@@ -19,8 +19,8 @@
     "core-js": "^3.6.4",
     "eslint": "^6.7.2",
     "eslint-config-airbnb-base": "^14.0.0",
-    "eslint-plugin-vue": "^6.1.2",
     "eslint-plugin-import": "^2.20.1",
+    "eslint-plugin-vue": "^6.1.2",
     "vue": "^2.6.11",
     "vue-template-compiler": "^2.6.11"
   },

--- a/vue/src/App.vue
+++ b/vue/src/App.vue
@@ -2,7 +2,15 @@
   <div id="app">
     <b-container>
       <banner />
-      <upload-form />
+      <upload-form
+        v-if="!finishedBeatUrl"
+        @done="finishedBeatUrl = $event"
+      />
+      <audio-player
+        v-else
+        :src="finishedBeatUrl"
+        @back="finishedBeatUrl = ''"
+      />
     </b-container>
   </div>
 </template>
@@ -10,11 +18,18 @@
 <script>
 import Banner from './components/Banner.vue';
 import UploadForm from './components/UploadForm.vue';
+import AudioPlayer from './components/AudioPlayer.vue';
 
 export default {
   components: {
     Banner,
     UploadForm,
+    AudioPlayer,
+  },
+  data() {
+    return {
+      finishedBeatUrl: '',
+    };
   },
 };
 </script>

--- a/vue/src/components/AudioPlayer.vue
+++ b/vue/src/components/AudioPlayer.vue
@@ -1,0 +1,29 @@
+<template>
+  <b-card header="Listen to your Beat">
+    <audio
+      style="display: block; width: 100%"
+      class="mb-4"
+      controls
+      :src="src"
+    >
+      Your browser does not support the audio element.
+    </audio>
+    <b-button
+      variant="danger"
+      @click="$emit('back')"
+    >
+      Start Over
+    </b-button>
+  </b-card>
+</template>
+
+<script>
+export default {
+  props: {
+    src: {
+      type: String,
+      required: true,
+    },
+  },
+};
+</script>

--- a/vue/src/components/UploadForm.vue
+++ b/vue/src/components/UploadForm.vue
@@ -1,45 +1,37 @@
 <template>
-  <b-card>
-    <b-card-body>
-      <b-alert
-        v-model="isFailed"
-        variant="danger"
-      >
-        {{ errorMessage }}
-      </b-alert>
-      <b-alert
-        v-model="isSuccess"
-        variant="success"
-      >
-        Successfully uploaded {{ file.name }}
-      </b-alert>
-      <b-form
-        v-if="!isSuccess"
-        @submit.prevent="submit"
-      >
-        <b-form-group>
-          <b-form-file
-            v-model="file"
-            accept="audio/*"
-            placeholder="Choose a beatbox audio file..."
-            drop-placeholder="Drop beatbox here..."
-            :disabled="isUploading"
-            required
-          />
-        </b-form-group>
-        <b-button
-          type="submit"
-          variant="primary"
+  <b-card
+    header="Create your Beat"
+    :footer="isUploading ? 'Your Beat is very important to us' : ''"
+  >
+    <b-alert
+      v-model="isFailed"
+      variant="danger"
+    >
+      {{ errorMessage }}
+    </b-alert>
+    <b-form @submit.prevent="submit">
+      <b-form-group>
+        <b-form-file
+          v-model="file"
+          accept="audio/*"
+          placeholder="Choose a beatbox audio file..."
+          drop-placeholder="Drop beatbox here..."
           :disabled="isUploading"
-        >
-          <b-spinner
-            v-if="isUploading"
-            small
-          />
-          Submit
-        </b-button>
-      </b-form>
-    </b-card-body>
+          required
+        />
+      </b-form-group>
+      <b-button
+        type="submit"
+        variant="primary"
+        :disabled="isUploading"
+      >
+        <b-spinner
+          v-if="isUploading"
+          small
+        />
+        {{ isUploading ? "Processing" : "Submit" }}
+      </b-button>
+    </b-form>
   </b-card>
 </template>
 
@@ -54,14 +46,13 @@ const STATUS_FAILED = 3;
 export default {
   data() {
     return {
-      file: [],
+      file: undefined,
       status: STATUS_INITIAL,
       errorMessage: '',
     };
   },
   computed: {
     isUploading() { return this.status === STATUS_UPLOADING; },
-    isSuccess() { return this.status === STATUS_SUCCESS; },
     isFailed() { return this.status === STATUS_FAILED; },
   },
   mounted() {
@@ -73,8 +64,9 @@ export default {
       formData.append('fileToUpload', this.file);
       this.status = STATUS_UPLOADING;
       try {
-        await axios.post('/upload', formData);
+        const { data } = await axios.post('/upload', formData);
         this.status = STATUS_SUCCESS;
+        this.$emit('done', data);
       } catch (err) {
         this.errorMessage = err;
         this.status = STATUS_FAILED;


### PR DESCRIPTION
* The main.py file upload handler now responds with a URL for a wav file
* Added an AudioPlayer.vue component which is an \<audio> tag with a back button
* Added a header and footer to the UploadForm.vue
* Made the UploadForm.vue emit an event when it receives the beat URL
* Made the App.vue switch between displaying the UploadForm.vue or AudioPlayer.vue based on whether it has received the beat URL